### PR TITLE
Feature/APP-3395 Non-Direct IAP Updates Listener

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
@@ -1,0 +1,54 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using System;
+
+// This class must match the name "AppCoinsPurchaseManager"
+public class AppCoinsPurchaseManager : MonoBehaviour
+{
+    private static AppCoinsPurchaseManager _instance;
+
+    public static event Action<PurchaseResponse> OnPurchaseUpdated;
+
+    public static AppCoinsPurchaseManager Instance
+    {
+        get
+        {
+            if (_instance == null)
+            {
+                GameObject obj = new GameObject("AppCoinsPurchaseManager");
+                _instance = obj.AddComponent<AppCoinsPurchaseManager>();
+                DontDestroyOnLoad(obj);
+            }
+            return _instance;
+        }
+    }
+
+    void Awake()
+    {
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        _instance = this;
+        DontDestroyOnLoad(gameObject);
+
+        AppCoinsSDK.StartObservingPurchases();
+    }
+
+    // This method name must match "OnPurchaseUpdated" from Swift
+    public void OnPurchaseUpdatedInternal(string purchaseJson)
+    {
+        Debug.Log($"Received Purchase Update: {purchaseJson}");
+        PurchaseResponse purchaseResponse = JsonUtility.FromJson<PurchaseResponse>(purchaseJson);
+        
+        NotifyPurchase(purchaseResponse);
+    }
+
+    // Call this method when a purchase is updated
+    public static void NotifyPurchase(PurchaseResponse purchaseResponse)
+    {
+        OnPurchaseUpdated?.Invoke(purchaseResponse);
+    }
+}

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
@@ -8,7 +8,7 @@ public class AppCoinsPurchaseManager : MonoBehaviour
 {
     private static AppCoinsPurchaseManager _instance;
 
-    // Subscribe to get notified of non-direct IAP
+    // Subscribe to get notified of indirect IAP
     public static event Action<PurchaseResponse> OnPurchaseUpdated;
 
     public static AppCoinsPurchaseManager Instance

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
@@ -8,6 +8,7 @@ public class AppCoinsPurchaseManager : MonoBehaviour
 {
     private static AppCoinsPurchaseManager _instance;
 
+    // Subscribe to get notified of non-direct IAP
     public static event Action<PurchaseResponse> OnPurchaseUpdated;
 
     public static AppCoinsPurchaseManager Instance
@@ -37,16 +38,13 @@ public class AppCoinsPurchaseManager : MonoBehaviour
         AppCoinsSDK.StartObservingPurchases();
     }
 
-    // This method name must match "OnPurchaseUpdated" from Swift
+    // This method name must match "OnPurchaseUpdatedInternal" from Swift
     public void OnPurchaseUpdatedInternal(string purchaseJson)
     {
-        Debug.Log($"Received Purchase Update: {purchaseJson}");
         PurchaseResponse purchaseResponse = JsonUtility.FromJson<PurchaseResponse>(purchaseJson);
-        
         NotifyPurchase(purchaseResponse);
     }
 
-    // Call this method when a purchase is updated
     public static void NotifyPurchase(PurchaseResponse purchaseResponse)
     {
         OnPurchaseUpdated?.Invoke(purchaseResponse);

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs.meta
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5dcaca92926f64d00bea326a9b872e55
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -350,7 +350,7 @@ public class AppCoinsSDK
     }
     #endregion
 
-    #region Start Observing Non-Direct Purchases
+    #region Start Observing Indirect Purchases
     public static void StartObservingPurchases()
     {
         if (_isObservingPurchases)

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -91,9 +91,12 @@ public class AppCoinsSDK
     public const string PURCHASE_STATE_USER_CANCELLED = "user_cancelled";
     public const string PURCHASE_STATE_FAILED = "failed";
 
-
     private static AppCoinsSDK _instance;
+    private static readonly object _lock = new object();
+
     private delegate void JsonCallback(string result);
+
+    private static bool _isObservingPurchases = false;
 
     [DllImport("__Internal")]
     private static extern void _handleDeepLink(string url, JsonCallback callback);
@@ -122,14 +125,31 @@ public class AppCoinsSDK
     [DllImport("__Internal")]
     private static extern IntPtr _getTestingWalletAddress();
 
+    [DllImport("__Internal")]
+    private static extern void _startPurchaseUpdates();
+
     public static AppCoinsSDK Instance
     {
         get
         {
-            _instance ??= new AppCoinsSDK();
-            Application.deepLinkActivated += HandleDeepLinkActivated;
+            if (_instance == null)
+            {
+                lock (_lock) // Thread-safe singleton
+                {
+                    if (_instance == null)
+                    {
+                        _instance = new AppCoinsSDK();
+                        Application.deepLinkActivated += HandleDeepLinkActivated;
+                    }
+                }
+            }
             return _instance;
         }
+    }
+
+    ~AppCoinsSDK()
+    {
+        Application.deepLinkActivated -= HandleDeepLinkActivated;
     }
 
     private static void HandleDeepLinkActivated(string url)
@@ -327,6 +347,17 @@ public class AppCoinsSDK
     {
         IntPtr ptr = _getTestingWalletAddress();
         return ptr == IntPtr.Zero ? null : Marshal.PtrToStringAnsi(ptr);
+    }
+    #endregion
+
+    #region Start Observing Non-Direct Purchases
+    public static void StartObservingPurchases()
+    {
+        if (_isObservingPurchases)
+            return; // Prevent multiple registrations
+        
+        _isObservingPurchases = true;
+        _startPurchaseUpdates();
     }
     #endregion
 

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -18,7 +18,7 @@ public static class SwiftPostProcess
 
             var targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTestTargetName());
 
-            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "1.2.0");
+            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "2.0.0");
             var mainTargetGuid = proj.GetUnityMainTargetGuid();
             var frameworkGuid = proj.GetUnityFrameworkTargetGuid();
             proj.AddRemotePackageFrameworkToProject(mainTargetGuid, "AppCoinsSDK", appCoinsGuid, false);

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin-Bridging-Header.h
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin-Bridging-Header.h
@@ -1,6 +1,18 @@
+// UnityPlugin-Bridging-Header.h
 
 #ifndef UnityPlugin_Bridging_Header_h
 #define UnityPlugin_Bridging_Header_h
 
+#include "UnityInterface.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void UnitySendMessage(const char *obj, const char *method, const char *msg);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* UnityPlugin_Bridging_Header_h */

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
@@ -272,7 +272,7 @@ public struct PurchaseData {
                 }
 
                 // 3) Send to Unity (the third parameter must be a C-string)
-                UnitySendMessageBridge("AppCoinsPurchaseManager", "OnPurchaseUpdated", cString)
+                UnitySendMessageBridge("AppCoinsPurchaseManager", "OnPurchaseUpdatedInternal", cString)
             }
         }
     }

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPluginBridge.mm
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPluginBridge.mm
@@ -179,4 +179,12 @@ extern "C" {
             return NULL;
         }
     }
+
+    void _startPurchaseUpdates() {
+        [UnityPlugin.shared startObservingPurchases];
+    }
+
+    void UnitySendMessageBridge(const char *objectName, const char *methodName, const char *message) {
+        UnitySendMessage(objectName, methodName, message);
+    }
 }


### PR DESCRIPTION
**What does this PR do?**

Adds a listener that will handle purchase updates for transactions that were not directly initiated within the application, such as those triggered via deep links. It integrates the `Purchase.updates` method from the Swift SDK, which returns a Stream of VerificationResult, allowing developers to receive updates on ongoing non-direct purchases, validate them, and attribute consumables to users.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin-Bridging-Header.h
- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPluginBridge.mm

**How should this be manually tested?**

Attempt to perform a purchase using a deep link (this will be dependent on new code being added to the demo application).

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3395](https://aptoide.atlassian.net/browse/APP-3395)

**Questions:**


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
