### PR TITLE
Bugfix/APP-3406 Purchase Deep Link Fails when App is Closed

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
@@ -8,6 +8,12 @@ public class AppCoinsPurchaseManager : MonoBehaviour
 {
     private static AppCoinsPurchaseManager _instance;
 
+    [RuntimeInitializeOnLoadMethod(RuntimeInitializeLoadType.BeforeSceneLoad)]
+    static void InitOnLoad()
+    {
+        _ = Instance; // Ensures the singleton is created at app startup
+    }
+
     // Subscribe to get notified of indirect IAP
     public static event Action<PurchaseResponse> OnPurchaseUpdated;
 

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -139,6 +139,15 @@ public class AppCoinsSDK
                     if (_instance == null)
                     {
                         _instance = new AppCoinsSDK();
+
+                        // Check for cold-start deep link (only if iOS)
+                        if (!string.IsNullOrEmpty(Application.absoluteURL))
+                        {
+                            #if UNITY_IOS && !UNITY_EDITOR
+                            _handleDeepLink(Application.absoluteURL, HandleDeepLinkResponse);
+                            #endif
+                        }
+
                         Application.deepLinkActivated += HandleDeepLinkActivated;
                     }
                 }


### PR DESCRIPTION
**What does this PR do?**

This pull request fixes an issue where when a user attempts to make a purchase via a deep link the process fails if the app is not already running. 

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs

**How should this be manually tested?**

   Test making purchases directly and through deep links on the SDK and verify the purchases are successful and consumed (dependent on the client application observing purchase updates).

**What are the relevant tickets?**

  Tickets related to this pull-request: APP-3406

**Questions:**

   Does this add new dependencies which need to be added? (Eg. new keys, etc.) 

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
