### PR TITLE
Feature/APP-3409 Crash on Non-Available Purchase

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -244,8 +244,21 @@ public class AppCoinsSDK
     [AOT.MonoPInvokeCallback(typeof(JsonCallback))]
     private static void OnPurchaseCompleted(string json)
     {
-        var response = JsonUtility.FromJson<PurchaseResponse>(json);
-        Instance._tcsPurchase.SetResult(response);
+        try
+        {
+            var response = JsonUtility.FromJson<PurchaseResponse>(json);
+            Instance._tcsPurchase?.TrySetResult(response); // Use TrySetResult to avoid exception if already set
+        }
+        catch (Exception ex)
+        {
+            var fallback = new PurchaseResponse
+            {
+                State = "failed",
+                Error = ex.ToString(),
+                Purchase = new PurchaseData()
+            };
+            Instance._tcsPurchase?.TrySetResult(fallback);
+        }
     }
 #endif
 

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
@@ -152,7 +152,7 @@ public struct PurchaseData {
         Task {
             do {
                 guard let product = try await Product.products(for: [sku]).first else {
-                    return completion(["State": "failed", "Error": "Product not found", "Purchase": ""])
+                    return completion(["State": "failed", "Error": "Product not found", "Purchase": [:]])
                 }
 
                 let result = await product.purchase(payload: payload.isEmpty ? nil : payload)
@@ -167,17 +167,17 @@ public struct PurchaseData {
                             return ["State": "unverified", "Error": verificationError.localizedDescription, "Purchase": PurchaseData(purchase: purchase).dictionaryRepresentation]
                         }
                     case .pending:
-                        return ["State": "pending", "Error": "", "Purchase": ""]
+                        return ["State": "pending", "Error": "", "Purchase": [:]]
                     case .userCancelled:
-                        return ["State": "user_cancelled", "Error": "", "Purchase": ""]
+                        return ["State": "user_cancelled", "Error": "", "Purchase": [:]]
                     case .failed(let error):
-                        return ["State": "failed", "Error": error.localizedDescription, "Purchase": ""]
+                        return ["State": "failed", "Error": error.localizedDescription, "Purchase": [:]]
                     }
                 }()
                 
                 completion(response)
             } catch {
-                completion(["State": "failed", "Error": error.localizedDescription, "Purchase": ""])
+                completion(["State": "failed", "Error": error.localizedDescription, "Purchase": [:]])
             }
         }
     }


### PR DESCRIPTION
**What does this PR do?**

This PR fixes a minor bug that caused the SDK to crash when a user attempted to initiate a purchase multiple times within a short period while the SDK was unavailable. This would not affect actual users considering developers only allow users to purchase items when the SDK is available.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift

**How should this be manually tested?**

It has been tested on the only device that seemed to have the issue.

**What are the relevant tickets?**

  Tickets related to this pull-request: APP-3409

**Questions:**


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
