### PR TITLE
Feature/APP-3510 Allow Deferred Indirect Purchase Handling

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
@@ -15,7 +15,7 @@ public class AppCoinsPurchaseManager : MonoBehaviour
     }
 
     // Subscribe to get notified of indirect IAP
-    public static event Action<PurchaseResponse> OnPurchaseUpdated;
+    public static event Action<PurchaseIntentData> OnPurchaseUpdated;
 
     public static AppCoinsPurchaseManager Instance
     {
@@ -45,14 +45,14 @@ public class AppCoinsPurchaseManager : MonoBehaviour
     }
 
     // This method name must match "OnPurchaseUpdatedInternal" from Swift
-    public void OnPurchaseUpdatedInternal(string purchaseJson)
+    public void OnPurchaseUpdatedInternal(string purchaseIntentJson)
     {
-        PurchaseResponse purchaseResponse = JsonUtility.FromJson<PurchaseResponse>(purchaseJson);
-        NotifyPurchase(purchaseResponse);
+        PurchaseIntentData purchaseIntent = JsonUtility.FromJson<PurchaseIntentData>(purchaseIntentJson);
+        NotifyPurchase(purchaseIntent);
     }
 
-    public static void NotifyPurchase(PurchaseResponse purchaseResponse)
+    public static void NotifyPurchase(PurchaseIntentData purchaseIntent)
     {
-        OnPurchaseUpdated?.Invoke(purchaseResponse);
+        OnPurchaseUpdated?.Invoke(purchaseIntent);
     }
 }

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -244,21 +244,8 @@ public class AppCoinsSDK
     [AOT.MonoPInvokeCallback(typeof(JsonCallback))]
     private static void OnPurchaseCompleted(string json)
     {
-        try
-        {
-            var response = JsonUtility.FromJson<PurchaseResponse>(json);
-            Instance._tcsPurchase?.TrySetResult(response); // Use TrySetResult to avoid exception if already set
-        }
-        catch (Exception ex)
-        {
-            var fallback = new PurchaseResponse
-            {
-                State = "failed",
-                Error = ex.ToString(),
-                Purchase = new PurchaseData()
-            };
-            Instance._tcsPurchase?.TrySetResult(fallback);
-        }
+        var response = JsonUtility.FromJson<PurchaseResponse>(json);
+        Instance._tcsPurchase.SetResult(response);
     }
 #endif
 

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -18,8 +18,7 @@ public static class SwiftPostProcess
 
             var targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTestTargetName());
 
-            // var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "2.0.0");
-            var appCoinsGuid = proj.AddRemotePackageReferenceAtBranch("https://github.com/Catappult/appcoins-sdk-ios.git", "feature/APP-3499_allow_developer_reject_indirect_purchase");
+            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "2.0.0");
             var mainTargetGuid = proj.GetUnityMainTargetGuid();
             var frameworkGuid = proj.GetUnityFrameworkTargetGuid();
             proj.AddRemotePackageFrameworkToProject(mainTargetGuid, "AppCoinsSDK", appCoinsGuid, false);

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -18,7 +18,8 @@ public static class SwiftPostProcess
 
             var targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTestTargetName());
 
-            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "2.0.0");
+            // var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "2.0.0");
+            var appCoinsGuid = proj.AddRemotePackageReferenceAtBranch("https://github.com/Catappult/appcoins-sdk-ios.git", "feature/APP-3499_allow_developer_reject_indirect_purchase");
             var mainTargetGuid = proj.GetUnityMainTargetGuid();
             var frameworkGuid = proj.GetUnityFrameworkTargetGuid();
             proj.AddRemotePackageFrameworkToProject(mainTargetGuid, "AppCoinsSDK", appCoinsGuid, false);
@@ -30,7 +31,10 @@ public static class SwiftPostProcess
             proj.AddBuildProperty(targetGuid, "LD_RUNPATH_SEARCH_PATHS", "@executable_path/Frameworks $(PROJECT_DIR)/lib/$(CONFIGURATION) $(inherited)");
             proj.AddBuildProperty(targetGuid, "FRAMERWORK_SEARCH_PATHS",
                 "$(inherited) $(PROJECT_DIR) $(PROJECT_DIR)/Frameworks");
-            proj.AddBuildProperty(targetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
+                
+            proj.SetBuildProperty(frameworkGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "NO");
+            proj.SetBuildProperty(mainTargetGuid, "ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES", "YES");
+
             proj.AddBuildProperty(targetGuid, "DYLIB_INSTALL_NAME_BASE", "@rpath");
             proj.AddBuildProperty(targetGuid, "LD_DYLIB_INSTALL_NAME",
                 "@executable_path/../Frameworks/$(EXECUTABLE_PATH)");

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
@@ -277,7 +277,7 @@ public struct PurchaseIntentData {
                     return completion(["State": "failed", "Error": "Intent not found", "Purchase": [:]])
                 }
 
-                let result = await intent.purchase(payload: payload.isEmpty ? nil : payload)
+                let result = await intent.confirm(payload: payload.isEmpty ? nil : payload)
                 
                 let response: [String: Any] = {
                     switch result {

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
@@ -116,6 +116,33 @@ public struct PurchaseData {
     }
 }
 
+public struct PurchaseIntentData {
+    public let id: String
+    public let product: ProductData
+    public let timestamp: String
+    
+    init(intent: PurchaseIntent) {
+        self.id = intent.id.uuidString
+        self.product = ProductData(product: intent.product)
+        
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(secondsFromGMT: 0)
+        formatter.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSZZZZZ"
+        self.timestamp = formatter.string(from: intent.timestamp)
+    }
+    
+    
+    var dictionaryRepresentation: [String: Any] {
+        var purchaseIntentDictionary = [String: Any]()
+        purchaseIntentDictionary["ID"] = self.id
+        purchaseIntentDictionary["Product"] = self.product.dictionaryRepresentation
+        purchaseIntentDictionary["Timestamp"] = self.timestamp
+        
+        return purchaseIntentDictionary
+    }
+}
+
 
 @objcMembers
 @objc public class UnityPlugin : NSObject {
@@ -152,7 +179,7 @@ public struct PurchaseData {
         Task {
             do {
                 guard let product = try await Product.products(for: [sku]).first else {
-                    return completion(["State": "failed", "Error": "Product not found", "Purchase": ""])
+                    return completion(["State": "failed", "Error": "Product not found", "Purchase": [:]])
                 }
 
                 let result = await product.purchase(payload: payload.isEmpty ? nil : payload)
@@ -167,21 +194,21 @@ public struct PurchaseData {
                             return ["State": "unverified", "Error": verificationError.localizedDescription, "Purchase": PurchaseData(purchase: purchase).dictionaryRepresentation]
                         }
                     case .pending:
-                        return ["State": "pending", "Error": "", "Purchase": ""]
+                        return ["State": "pending", "Error": "", "Purchase": [:]]
                     case .userCancelled:
-                        return ["State": "user_cancelled", "Error": "", "Purchase": ""]
+                        return ["State": "user_cancelled", "Error": "", "Purchase": [:]]
                     case .failed(let error):
-                        return ["State": "failed", "Error": error.localizedDescription, "Purchase": ""]
+                        return ["State": "failed", "Error": error.localizedDescription, "Purchase": [:]]
                     }
                 }()
                 
                 completion(response)
             } catch {
-                completion(["State": "failed", "Error": error.localizedDescription, "Purchase": ""])
+                completion(["State": "failed", "Error": error.localizedDescription, "Purchase": [:]])
             }
         }
     }
-
+    
     @objc public func getAllPurchases(completion: @escaping ([[String: Any]]) -> Void) {
         Task {
             do {
@@ -234,6 +261,57 @@ public struct PurchaseData {
         return Sandbox.getTestingWalletAddress()
     }
     
+    @objc public func getPurchaseIntent(completion: @escaping ([String: Any]) -> Void) {
+        guard let intent = Purchase.intent else {
+            completion([:])
+            return
+        }
+    
+        completion(PurchaseIntentData(intent: intent).dictionaryRepresentation)
+    }
+    
+    @objc public func confirmPurchaseIntent(payload: String, completion: @escaping ([String: Any]) -> Void) {
+        Task {
+            do {
+                guard let intent = Purchase.intent else {
+                    return completion(["State": "failed", "Error": "Intent not found", "Purchase": [:]])
+                }
+
+                let result = await intent.purchase(payload: payload.isEmpty ? nil : payload)
+                
+                let response: [String: Any] = {
+                    switch result {
+                    case .success(let verificationResult):
+                        switch verificationResult {
+                        case .verified(let purchase):
+                            return ["State": "success", "Error": "", "Purchase": PurchaseData(purchase: purchase).dictionaryRepresentation]
+                        case .unverified(let purchase, let verificationError):
+                            return ["State": "unverified", "Error": verificationError.localizedDescription, "Purchase": PurchaseData(purchase: purchase).dictionaryRepresentation]
+                        }
+                    case .pending:
+                        return ["State": "pending", "Error": "", "Purchase": [:]]
+                    case .userCancelled:
+                        return ["State": "user_cancelled", "Error": "", "Purchase": [:]]
+                    case .failed(let error):
+                        return ["State": "failed", "Error": error.localizedDescription, "Purchase": [:]]
+                    }
+                }()
+                
+                completion(response)
+            } catch {
+                completion(["State": "failed", "Error": error.localizedDescription, "Purchase": [:]])
+            }
+        }
+    }
+    
+    @objc public func rejectPurchaseIntent() {
+        guard let intent = Purchase.intent else {
+            return
+        }
+        
+        intent.reject()
+    }
+    
     // The Task that listens for Purchase.updates
     private var task: Task<Void, Never>?
     // Flag to track if we're already observing
@@ -246,28 +324,13 @@ public struct PurchaseData {
 
         task = Task(priority: .background) {
             // Because Purchase.updates yields VerificationResult<Purchase> in your snippet
-            for await verificationResult in Purchase.updates {
+            for await intent in Purchase.updates {
                 
-                // 1) Build a dictionary describing the verification result
-                let response: [String: Any] = {
-                    switch verificationResult {
-                    case .verified(let purchase):
-                        return [
-                            "State": "success",
-                            "Error": "",
-                            "Purchase": PurchaseData(purchase: purchase).dictionaryRepresentation
-                        ]
-                    case .unverified(let purchase, let verificationError):
-                        return [
-                            "State": "unverified",
-                            "Error": verificationError.localizedDescription,
-                            "Purchase": PurchaseData(purchase: purchase).dictionaryRepresentation
-                        ]
-                    }
-                }()
+                // 1) Build a dictionary describing the intent
+                let intentData: [String: Any] = PurchaseIntentData(intent: intent).dictionaryRepresentation
                 
                 // 2) Serialize that dictionary to JSON
-                guard let cString = dictionaryToCString(response) else {
+                guard let cString = dictionaryToCString(intentData) else {
                     continue // if serialization fails, skip
                 }
 

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPluginBridge.mm
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPluginBridge.mm
@@ -180,6 +180,50 @@ extern "C" {
         }
     }
 
+    void _getPurchaseIntent(JsonCallback callback) {
+        [UnityPlugin.shared getPurchaseIntentWithCompletion:^(NSDictionary *data) {
+            NSError *error = nil;
+            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:data options:0 error:&error];
+            if (!jsonData) {
+                NSLog(@"Failed to serialize JSON: %@", error);
+                if (callback) {
+                    callback(""); // Call with an empty string or error message
+                }
+                return;
+            }
+
+            NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+            if (callback) {
+                callback([jsonString UTF8String]);
+            }
+        }];
+    }
+
+    void _confirmPurchaseIntent(const char *payload, JsonCallback callback) {
+        NSString *payloadString = [NSString stringWithUTF8String:payload];
+        
+        [UnityPlugin.shared confirmPurchaseIntentWithPayload:payloadString completion:^(NSDictionary *data) {
+            NSError *error = nil;
+            NSData *jsonData = [NSJSONSerialization dataWithJSONObject:data options:0 error:&error];
+            if (!jsonData) {
+                NSLog(@"Failed to serialize JSON: %@", error);
+                if (callback) {
+                    callback(""); // Call with an empty string or error message
+                }
+                return;
+            }
+            
+            NSString *jsonString = [[NSString alloc] initWithData:jsonData encoding:NSUTF8StringEncoding];
+            if (callback) {
+                callback([jsonString UTF8String]);
+            }
+        }];
+    }
+
+    void _rejectPurchaseIntent() {
+        [UnityPlugin.shared rejectPurchaseIntent];
+    }
+
     void _startPurchaseUpdates() {
         [UnityPlugin.shared startObservingPurchases];
     }


### PR DESCRIPTION
**What does this PR do?**

This PR enables the SDK to support deferred handling of Indirect Purchases. Instead of automatically prompting the user upon app launch, the SDK now stores the pending purchase intent and allows the developer to decide when to handle it, based on their game logic.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Sources/AppCoinsSDK/Domain/Entities/AppcSDK.swift
- [ ] Sources/AppCoinsSDK/Domain/Entities/Purchase.swift
- [ ] Sources/AppCoinsSDK/Domain/Entities/PurchaseIntent.swift

**How should this be manually tested?**

This can be tested by using the newest version of Trivial Drive with a login button which only allows to perform indirect purchases after the user performs the login.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3498](https://aptoide.atlassian.net/browse/APP-3498)

**Questions:**



**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
