### PR TITLE
Feature/APP-3919 Adapt Unity Plugin SDK v4

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -18,7 +18,8 @@ public static class SwiftPostProcess
 
             var targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTestTargetName());
 
-            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "3.0.0");
+            var appCoinsGuid = proj.AddRemotePackageReferenceAtBranch("https://github.com/Catappult/appcoins-sdk-ios.git", "release_4.0.0");
+            // var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "3.0.0");
             var mainTargetGuid = proj.GetUnityMainTargetGuid();
             var frameworkGuid = proj.GetUnityFrameworkTargetGuid();
             proj.AddRemotePackageFrameworkToProject(mainTargetGuid, "AppCoinsSDK", appCoinsGuid, false);

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift
@@ -256,6 +256,10 @@ public struct AppCoinsSDKErrorData {
 @objc public class UnityPlugin : NSObject {
     
     @objc public static let shared = UnityPlugin()
+    
+    @objc public func initialize() {
+        AppcSDK.initialize()
+    }
 
     @objc public func handleDeepLink(url: String, completion: @escaping ([String: Any]) -> Void) {
         Task {
@@ -423,8 +427,11 @@ public struct AppCoinsSDKErrorData {
         }
     }
     
-    @objc public func getTestingWalletAddress() -> String? {
-        return Sandbox.getTestingWalletAddress()
+    @objc public func getTestingWalletAddress(completion: @escaping ([String: Any]) -> Void) {
+        Task {
+            let address = await Sandbox.getTestingWalletAddress()
+            completion( ["IsSuccess": true, "Value": address ?? ""] )
+        }
     }
     
     @objc public func getPurchaseIntent(completion: @escaping ([String: Any]) -> Void) {

--- a/README.md
+++ b/README.md
@@ -413,17 +413,6 @@ Where:
 
 To verify the successful setup of your billing integration, we offer a sandbox environment where you can simulate purchases and ensure that your clients can smoothly purchase your products. Documentation on how to use this environment can be found at: [Sandbox](https://docs.connect.aptoide.com/docs/ios-sandbox-environment)
 
-#### Testing In-App Purchases
-
-1. Select the item you wish to purchase in the app.
-2. Choose the **Sandbox** option for the transaction.
-3. Once the purchase is completed, verify the transaction in the Wallet by checking the **Sandbox transactions**.
-4. Ensure the purchased item is correctly received in the app.
-
-If all steps are successful, your billing solution is fully integrated!
-
-For more detailed instructions, refer to [Catappult's documentation](https://docs.catappult.io/docs/ios-sandbox-environment).
-
 ## Classes Definition and Properties
 
 The Unity Plugin integration is based on several main classes of objects that handle its logic:

--- a/README.md
+++ b/README.md
@@ -411,14 +411,7 @@ Where:
 
 ### Sandbox Testing
 
-You can test the in-app purchase (IAP) functionality using Catappult’s **Sandbox environment**. Follow these steps to set it up:
-
-1. Retrieve your testing wallet address by calling `AppCoinsSDK.Instance.GetTestingWalletAddress()`.
-2. Add your testing wallet address to the **Sandbox menu** in the Developer Console, and use this wallet to make test purchases in your app.
-
-> ⚠️ **Warning:** You must have proven ownership of the app to access the Sandbox environment and test IAPs.
-
-> ⚠️ **Warning:** Do not delete the app from the testing device, as this will remove the testing wallet. If the app is deleted, you’ll need to obtain a new wallet address and add it again to the Sandbox.
+To verify the successful setup of your billing integration, we offer a sandbox environment where you can simulate purchases and ensure that your clients can smoothly purchase your products. Documentation on how to use this environment can be found at: [Sandbox](https://docs.connect.aptoide.com/docs/ios-sandbox-environment)
 
 #### Testing In-App Purchases
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-The iOS Billing SDK is a straightforward solution for implementing Catappult billing. Its Unity Plugin provides a simple interface for Unity games to communicate with the SDK. It comprises a Billing client that integrates with AppCoins Wallet, enabling you to retrieve your products from Catappult and facilitate the purchase of those items.
+The iOS Billing SDK is a simple solution to implement Aptoide billing. Its Unity Plugin provides a simple interface for Unity games to communicate with the SDK. It consists of a Billing client that allows you to get your products from Aptoide Connect and process the purchase of those items.
 
 ## In Summary
 
@@ -27,7 +27,7 @@ The billing flow in your application with the Plugin is as follows:
 Now that you have the Plugin set-up you can start making use of its functionalities.
 
 1. **Check AppCoins Billing Availability**  
-   The AppCoins Billing will only be available on devices in the European Union with an iOS version equal to or higher than 17.4 and only in applications distributed through the Aptoide iOS App Store. Therefore, before attempting any purchase, you should check if the SDK is available by calling `AppCoinsSDK.Instance.IsAvailable()`.
+   The AppCoins Billing will only be available on devices with an iOS version equal to or higher than 17.4 and only if the application was not installed through the Apple App St. Therefore, before attempting any purchase, you should check if the SDK is available by calling `AppCoinsSDK.Instance.IsAvailable()`.
 
    ```csharp
    var isAvailable = await AppCoinsSDK.Instance.IsAvailable();

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ The billing flow in your application with the Plugin is as follows:
 Now that you have the Plugin set-up you can start making use of its functionalities.
 
 1. **Check AppCoins Billing Availability**  
+   
    The AppCoins Billing will only be available on devices with an iOS version equal to or higher than 17.4 and only if the application was not installed through the Apple App St. Therefore, before attempting any purchase, you should check if the SDK is available by calling `AppCoinsSDK.Instance.IsAvailable()`.
 
    ```csharp
@@ -38,6 +39,7 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    }
    ```
 2. **Query In-App Products**
+   
    You should start by getting the In-App Products you want to make available to the user. This method can either return all of your Catappult In-App Products or a specific list.
 
    1. `AppCoinsSDK.Instance.GetProducts()`
@@ -79,6 +81,7 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    > ⚠️ **Warning:** You will only be able to query your In-App Products once your application is reviewed and approved on Aptoide Connect.
    
 3. **Purchase In-App Product**
+   
    To purchase an In-App Product you must call the function `AppCoinsSDK.Instance.Purchase(sku, payload)`. The Plugin will handle all of the purchase logic for you and it will return you on completion the result of the purchase. This result is an `AppCoinsSDKPurchaseResult` object with the following properties:
 
    1. `State`: String - The purchase state (`AppCoinsSDK.PURCHASE_STATE_SUCCESS`, `AppCoinsSDK.PURCHASE_STATE_PENDING`, `AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED`, `AppCoinsSDK.PURCHASE_STATE_FAILED`)
@@ -297,6 +300,7 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    ```
 
 6. **Query Purchases**
+
    You can query the user's purchases by using one of the following methods:
 
    1. `AppCoinsSDK.Instance.GetAllPurchases()`

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The billing flow in your application with the Plugin is as follows:
 Now that you have the Plugin set-up you can start making use of its functionalities.
 
 1. **Check AppCoins Billing Availability**  
-   The AppCoins Billing will only be available on devices with an iOS version equal to or higher than 17.4 and only if the application was not installed through the Apple App St. Therefore, before attempting any purchase, you should check if the SDK is available by calling `AppCoinsSDK.Instance.IsAvailable()`.
+   The AppCoins Billing will only be available on devices with an iOS version equal to or higher than 17.4 and only if the application was not installed through the Apple App Store. Therefore, before attempting any purchase, you should check if the SDK is available by calling `AppCoinsSDK.Instance.IsAvailable()`.
 
    ```csharp
    var isAvailable = await AppCoinsSDK.Instance.IsAvailable();

--- a/README.md
+++ b/README.md
@@ -37,59 +37,109 @@ Now that you have the Plugin set-up you can start making use of its functionalit
      // make purchase
    }
    ```
-2. **Query In-App Products**  
-   You should start by getting the In-App Products you want to make available to the user. You can do this by calling `Product.products`.  
-   This method can either return all of your Catappult In-App Products or a specific list.
+2. **Query In-App Products**
+   You should start by getting the In-App Products you want to make available to the user. This method can either return all of your Catappult In-App Products or a specific list.
 
    1. `AppCoinsSDK.Instance.GetProducts()`
 
       Returns all application Catappult In-App Products:
 
       ```csharp
-      var products = await AppCoinsSDK.Instance.GetProducts();
+      var productsResult = await AppCoinsSDK.Instance.GetProducts();
+
+      if (productsResult.IsSuccess)
+      {
+          var products = productsResult.Value;
+          // Process products
+      }
+      else
+      {
+          Debug.Log("Error: " + productsResult.Error);
+      }
       ```
+
    2. `AppCoinsSDK.Instance.GetProducts(skus)`
 
       Returns a specific list of Catappult In-App Products:
 
       ```csharp
-      var products = await AppCoinsSDK.Instance.GetProducts(new string[] { "coins_100", "gas" });
+      var productsResult = await AppCoinsSDK.Instance.GetProducts(new string[] { "coins_100", "gas" });
+
+      if (productsResult.IsSuccess)
+      {
+          var products = productsResult.Value;
+          // Process products
+      }
+      else
+      {
+          Debug.Log("Error: " + productsResult.Error);
+      }
       ```
 
    > ⚠️ **Warning:** You will only be able to query your In-App Products once your application is reviewed and approved on Aptoide Connect.
    
-3. **Purchase In-App Product**  
-   To purchase an In-App Product you must call the function `AppCoinsSDK.Instance.Purchase(sku, payload)`. The Plugin will handle all of the purchase logic for you and it will return you on completion the result of the purchase. This result is an object with the following properties:        
+3. **Purchase In-App Product**
+   To purchase an In-App Product you must call the function `AppCoinsSDK.Instance.Purchase(sku, payload)`. The Plugin will handle all of the purchase logic for you and it will return you on completion the result of the purchase. This result is an `AppCoinsSDKPurchaseResult` object with the following properties:
 
-   1. State: `string` (`AppCoinsSDK.PURCHASE_STATE_SUCCESS`, `AppCoinsSDK.PURCHASE_STATE_UNVERIFIED`, `AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED`, `AppCoinsSDK.PURCHASE_STATE_FAILED`)
-   2. Error: `string`
-   3. Purchase: `PurchaseData`
+   1. `State`: String - The purchase state (`AppCoinsSDK.PURCHASE_STATE_SUCCESS`, `AppCoinsSDK.PURCHASE_STATE_PENDING`, `AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED`, `AppCoinsSDK.PURCHASE_STATE_FAILED`)
+   2. `Value`: Object containing:
+      - `VerificationResult`: String - The verification result (`AppCoinsSDK.PURCHASE_VERIFICATION_STATE_VERIFIED`, `AppCoinsSDK.PURCHASE_VERIFICATION_STATE_UNVERIFIED`)
+      - `Purchase`: Purchase object
+      - `VerificationError`: AppCoinsSDKError (only present if verification fails)
+   3. `Error`: AppCoinsSDKError - Error details (only present if state is `FAILED`)
 
-   In case of success the application will verify the transaction’s signature locally. After this verification you should handle its result:
+   In case of success the application will verify the transaction's signature locally. After this verification you should handle its result:
 
    1. If the purchase is verified you should consume the item and give it to the user.
    2. If it is not verified you need to make a decision based on your business logic, you either still consume the item and give it to the user, or otherwise the purchase will not be acknowledged and we will refund the user in 24 hours.
 
    In case of failure you can deal with different types of errors.
 
-   You can also pass a Payload to the purchase method in order to associate some sort of information with a specific purchase. You can use this for example to associate a specific user with a Purchase: `gas.purchase(payload: "User123")`.  
+   You can also pass a Payload to the purchase method in order to associate some sort of information with a specific purchase. You can use this for example to associate a specific user with a Purchase: `AppCoinsSDK.Instance.Purchase("gas", "User123")`.
    <br/>
 
    ```csharp
-   var purchaseResponse = await AppCoinsSDK.Instance.Purchase("gas", "User123");
+   var purchaseResult = await AppCoinsSDK.Instance.Purchase("gas", "User123");
 
-   if (purchaseResponse.State == AppCoinsSDK.PURCHASE_STATE_SUCCESS)
+   switch (purchaseResult.State)
    {
-     var response = await AppCoinsSDK.Instance.ConsumePurchase(purchaseResponse.PurchaseSku);
+       case AppCoinsSDK.PURCHASE_STATE_SUCCESS:
+           switch (purchaseResult.Value.VerificationResult)
+           {
+               case AppCoinsSDK.PURCHASE_VERIFICATION_STATE_VERIFIED:
+                   // Consume the item and give it to the user
+                   var consumeResult = await AppCoinsSDK.Instance.ConsumePurchase(purchaseResult.Value.Purchase.Sku);
 
-     if (response.Success)
-     {
-         Debug.Log("Purchase consumed successfully");
-     }
-     else
-     {
-         Debug.Log("Error consuming purchase: " + response.Error);
-     }
+                   if (consumeResult.IsSuccess)
+                   {
+                       Debug.Log("Purchase consumed successfully");
+                   }
+                   else
+                   {
+                       Debug.Log("Error consuming purchase: " + consumeResult.Error);
+                   }
+                   break;
+
+               case AppCoinsSDK.PURCHASE_VERIFICATION_STATE_UNVERIFIED:
+                   // Handle unverified purchase according to your game logic
+                   break;
+           }
+           break;
+
+       case AppCoinsSDK.PURCHASE_STATE_PENDING:
+           // Handle pending purchase according to your game logic
+           Debug.Log("Purchase is pending.");
+           break;
+
+       case AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED:
+           // Handle cancelled purchase according to your game logic
+           Debug.Log("Purchase was cancelled.");
+           break;
+
+       case AppCoinsSDK.PURCHASE_STATE_FAILED:
+           // Handle failed purchase according to your game logic
+           Debug.Log("Purchase failed with error: " + purchaseResult.Error);
+           break;
    }
    ```
 4. **Handle Indirect Purchases**
@@ -99,72 +149,158 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    1. Purchasing an item directly from a catalog of In-App Products in the Aptoide Store.
    2. Buying an item through a web link.
 
-   The `AppCoinsPurchaseManager.OnPurchaseUpdated` Unity Action allows developers to manage these purchases and assign consumables to users. This action continuously streams purchase updates, ensuring real-time transaction synchronization.
+   The `AppCoinsPurchaseManager.OnPurchaseUpdated` Unity Action allows developers to manage these purchase intents. This event continuously streams purchase intent updates, ensuring real-time transaction synchronization.
 
-   The event returns a `PurchaseResponse` object, which should be handled in the same way as a standard In-App Purchase.
+   The event returns a `PurchaseIntent` object containing:
+   - `ID`: String - Unique identifier for the intent
+   - `Product`: Product - The product the user wants to purchase
+   - `Timestamp`: String - When the intent was created
 
-   To properly handle purchase updates, define the subscription within a singleton class, ensuring it remains active for the application’s lifecycle. Use the same HandlePurchase method applied to standard purchases.
+   When you receive a `PurchaseIntent`, you must either **confirm** it using `AppCoinsSDK.Instance.ConfirmPurchaseIntent(payload)` to complete the purchase, or **reject** it using `AppCoinsSDK.Instance.RejectPurchaseIntent()` to cancel. Confirming the intent returns an `AppCoinsSDKPurchaseResult` that should be handled the same way as a standard purchase.
+
+   To properly handle purchase intents, subscribe to the event within a singleton class, ensuring it remains active for the application's lifecycle.
+
+   **Note:** You can also manually check for pending purchase intents using `AppCoinsSDK.Instance.GetPurchaseIntent()`. This is useful when the user signs in or when your app becomes active, to ensure no pending intents are missed.
    <br/>
 
    ```csharp
    private void Awake()
    {
-     // Singleton enforcement
-     if (Instance != null && Instance != this)
-     {
-       Destroy(gameObject);  // Destroy duplicate instances
-       return;
-     }
-     
-     Instance = this;
-     DontDestroyOnLoad(gameObject); // Persist across scenes
-     
-     // Subscribe to purchase updates
-     AppCoinsPurchaseManager.OnPurchaseUpdated += HandlePurchase;
+       // Singleton enforcement
+       if (Instance != null && Instance != this)
+       {
+           Destroy(gameObject);  // Destroy duplicate instances
+           return;
+       }
+
+       Instance = this;
+       DontDestroyOnLoad(gameObject); // Persist across scenes
+
+       // Subscribe to purchase intent updates
+       AppCoinsPurchaseManager.OnPurchaseUpdated += HandlePurchaseIntent;
    }
-   
-   // Already defined previously
-   async public void HandlePurchase(PurchaseResponse purchaseResponse)
+
+   private async void HandlePurchaseIntent(PurchaseIntent purchaseIntent)
    {
-     if (purchaseResponse.State == AppCoinsSDK.PURCHASE_STATE_SUCCESS)
-     {
-       var response = await AppCoinsSDK.Instance.ConsumePurchase(purchaseResponse.PurchaseSku);
-       
-       if (response.Success)
+       Debug.Log($"Received purchase intent for: {purchaseIntent.Product.Title}");
+
+       // Confirm the purchase intent to complete the transaction
+       var purchaseResult = await AppCoinsSDK.Instance.ConfirmPurchaseIntent("User123");
+
+       // Handle the purchase result the same way as a standard purchase
+       switch (purchaseResult.State)
        {
-         Debug.Log("Purchase consumed successfully");
+           case AppCoinsSDK.PURCHASE_STATE_SUCCESS:
+               switch (purchaseResult.Value.VerificationResult)
+               {
+                   case AppCoinsSDK.PURCHASE_VERIFICATION_STATE_VERIFIED:
+                       var consumeResult = await AppCoinsSDK.Instance.ConsumePurchase(purchaseResult.Value.Purchase.Sku);
+
+                       if (consumeResult.IsSuccess)
+                       {
+                           Debug.Log("Purchase consumed successfully");
+                       }
+                       else
+                       {
+                           Debug.Log("Error consuming purchase: " + consumeResult.Error);
+                       }
+                       break;
+
+                   case AppCoinsSDK.PURCHASE_VERIFICATION_STATE_UNVERIFIED:
+                       // Handle unverified purchase according to your game logic
+                       break;
+               }
+               break;
+
+           case AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED:
+               Debug.Log("Purchase was cancelled.");
+               break;
+
+           case AppCoinsSDK.PURCHASE_STATE_FAILED:
+               Debug.Log("Purchase failed with error: " + purchaseResult.Error);
+               break;
        }
-       else
-       {
-         Debug.Log("Error consuming purchase: " + response.Error);
-       }
-     }
+
+       // Alternatively, reject the purchase intent to cancel:
+       // AppCoinsSDK.Instance.RejectPurchaseIntent();
    }
    ```
 
-5. **Query Purchases**  
-   You can query the user’s purchases by using one of the following methods:
+5. **Query Purchases**
+   You can query the user's purchases by using one of the following methods:
 
    1. `AppCoinsSDK.Instance.GetAllPurchases()`
 
       This method returns all purchases that the user has performed in your application.
 
       ```csharp
-      var purchases = await AppCoinsSDK.Instance.GetAllPurchases();
+      var purchasesResult = await AppCoinsSDK.Instance.GetAllPurchases();
+
+      if (purchasesResult.IsSuccess)
+      {
+          var purchases = purchasesResult.Value;
+          // Process purchases
+      }
+      else
+      {
+          Debug.Log("Error: " + purchasesResult.Error);
+      }
       ```
+
    2. `AppCoinsSDK.Instance.GetLatestPurchase(string sku)`
 
-      This method returns the latest user purchase for a specific In-App Product.
+      This method returns the latest user purchase for a specific In-App Product. Returns `null` if no purchase is found.
 
       ```csharp
-      var latestPurchase = await AppCoinsSDK.Instance.GetLatestPurchase("gas");
+      var latestPurchaseResult = await AppCoinsSDK.Instance.GetLatestPurchase("gas");
+
+      if (latestPurchaseResult.IsSuccess)
+      {
+          if (latestPurchaseResult.Value != null)
+          {
+              var purchase = latestPurchaseResult.Value;
+              // Process purchase
+          }
+          else
+          {
+              Debug.Log("No latest purchase found for this SKU");
+          }
+      }
+      else
+      {
+          Debug.Log("Error: " + latestPurchaseResult.Error);
+      }
       ```
+
    3. `AppCoinsSDK.Instance.GetUnfinishedPurchases()`
 
-      This method returns all of the user’s unfinished purchases in the application. An unfinished purchase is any purchase that has neither been acknowledged (verified by the SDK) nor consumed. You can use this method for consuming any unfinished purchases.
+      This method returns all of the user's unfinished purchases in the application. An unfinished purchase is any purchase that has neither been acknowledged (verified by the SDK) nor consumed. You can use this method for consuming any unfinished purchases.
 
       ```csharp
-      var unfinishedPurchases = await AppCoinsSDK.Instance.GetUnfinishedPurchases();
+      var unfinishedPurchasesResult = await AppCoinsSDK.Instance.GetUnfinishedPurchases();
+
+      if (unfinishedPurchasesResult.IsSuccess)
+      {
+          var purchases = unfinishedPurchasesResult.Value;
+
+          foreach (var purchase in purchases)
+          {
+              var consumeResult = await AppCoinsSDK.Instance.ConsumePurchase(purchase.Sku);
+
+              if (consumeResult.IsSuccess)
+              {
+                  Debug.Log("Unfinished purchase consumed successfully");
+              }
+              else
+              {
+                  Debug.Log("Error consuming purchase: " + consumeResult.Error);
+              }
+          }
+      }
+      else
+      {
+          Debug.Log("Error: " + unfinishedPurchasesResult.Error);
+      }
       ```
 
 ### Testing
@@ -223,25 +359,25 @@ For more detailed instructions, refer to [Catappult's documentation](https://doc
 
 ## Classes Definition and Properties
 
-The Unity Plugin integration is based on three main classes of objects that handle its logic:
+The Unity Plugin integration is based on several main classes of objects that handle its logic:
 
-### ProductData
+### Product
 
-`ProductData` represents an in-app product.
+`Product` represents an in-app product.
 
 **Properties:**
 
 - `Sku`: String - Unique product identifier. Example: gas
 - `Title`: String - The product display title. Example: Best Gas
-- `Description`: String? - The product description. Example: Buy gas to fill the tank.
-- `PriceCurrency`: String - The user’s geolocalized currency. Example: EUR
+- `Description`: String - The product description. Example: Buy gas to fill the tank.
+- `PriceCurrency`: String - The user's geolocalized currency. Example: EUR
 - `PriceValue`: String - The value of the product in the specified currency. Example: 0.93
 - `PriceLabel`: String - The label of the price displayed to the user. Example: €0.93
 - `PriceSymbol`: String - The symbol of the geolocalized currency. Example: €
 
-### PurchaseData
+### Purchase
 
-`PurchaseData` represents an in-app purchase.
+`Purchase` represents an in-app purchase.
 
 **Properties:**
 
@@ -277,7 +413,79 @@ The Unity Plugin integration is based on three main classes of objects that hand
 - `PurchaseState`: Integer - The purchase state of the order. Possible values are: 0 (Purchased) and 1 (Canceled)
 - `DeveloperPayload`: String - A developer-specified string that contains supplemental information about an order. Example: myOrderId:12345678
 
+### PurchaseIntent
+
+`PurchaseIntent` represents an indirect in-app purchase intent.
+
+**Properties:**
+
+- `ID`: String - Unique identifier for the intent. Example: 550e8400-e29b-41d4-a716-446655440000
+- `Product`: Product - The product the user wants to purchase
+- `Timestamp`: String - When the intent was created. Example: 2025-01-15T10:21:29.014456Z
+
+### AppCoinsSDKPurchaseResult
+
+`AppCoinsSDKPurchaseResult` represents the result of a purchase operation.
+
+**Properties:**
+
+- `State`: String - The purchase state. Can be:
+  - `AppCoinsSDK.PURCHASE_STATE_SUCCESS` - Purchase completed successfully
+  - `AppCoinsSDK.PURCHASE_STATE_PENDING` - Purchase is pending
+  - `AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED` - User cancelled the purchase
+  - `AppCoinsSDK.PURCHASE_STATE_FAILED` - Purchase failed
+- `Value`: Object (only present when State is SUCCESS) containing:
+  - `VerificationResult`: String - Can be `AppCoinsSDK.PURCHASE_VERIFICATION_STATE_VERIFIED` or `AppCoinsSDK.PURCHASE_VERIFICATION_STATE_UNVERIFIED`
+  - `Purchase`: Purchase - The purchase object
+  - `VerificationError`: AppCoinsSDKError (optional) - Error details if verification failed
+- `Error`: AppCoinsSDKError (only present when State is FAILED) - Error details
+
+### AppCoinsSDKResult&lt;T&gt;
+
+`AppCoinsSDKResult<T>` represents the result of SDK operations that return data.
+
+**Properties:**
+
+- `IsSuccess`: Boolean - Whether the operation succeeded
+- `Value`: T - The result value (only present when IsSuccess is true)
+- `Error`: AppCoinsSDKError (only present when IsSuccess is false) - Error details
+
+**Used by:**
+- `GetProducts()` - Returns `AppCoinsSDKResult<Product[]>`
+- `GetAllPurchases()` - Returns `AppCoinsSDKResult<Purchase[]>`
+- `GetLatestPurchase(sku)` - Returns `AppCoinsSDKResult<Purchase>`
+- `GetUnfinishedPurchases()` - Returns `AppCoinsSDKResult<Purchase[]>`
+- `ConsumePurchase(sku)` - Returns `AppCoinsSDKResult<bool>`
+- `GetTestingWalletAddress()` - Returns `AppCoinsSDKResult<string>`
+- `GetPurchaseIntent()` - Returns `AppCoinsSDKResult<PurchaseIntent>`
+
+### AppCoinsSDKError
+
+`AppCoinsSDKError` represents error information when an SDK operation fails.
+
+**Properties:**
+
+- `Type`: String - The error type. Can be:
+  - `networkError` - Network-related error
+  - `systemError` - System or SDK error
+  - `notEntitled` - User is not entitled to the product
+  - `productUnavailable` - Product is not available
+  - `purchaseNotAllowed` - Purchase is not allowed
+  - `unknown` - Unknown error
+- `Message`: String - A brief error message
+- `Description`: String - A detailed error description
+- `Request`: ErrorRequest (optional) - Request details if available
+
+#### ErrorRequest
+
+**Properties:**
+
+- `URL`: String - The request URL
+- `Method`: String - The HTTP method
+- `Body`: String - The request body
+- `ResponseData`: String - The response data
+- `StatusCode`: Integer - The HTTP status code
 
 ### AppCoinsSDK
 
-This class is responsible for general purpose methods.
+This class is responsible for general purpose methods and provides singleton access via `AppCoinsSDK.Instance`.


### PR DESCRIPTION
**What does this PR do?**

Adapts the Unity SDK to the v4 version of the SDK by reinstating the getTestingWalletAddres and using the initialize method automatically on load.

**Database changed?**

   No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Source/UnityPlugin.swift

**How should this be manually tested?**

Already tested with multiple payment methods and flows.

**What are the relevant tickets?**

  Tickets related to this pull-request: [APP-3919](https://aptoide.atlassian.net/browse/APP-3919)

**Questions:**


**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass
