### PR TITLE
Bugfix/APP-4060 Fix duplicate class warnings by linking SDK only to UnityFramework

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -18,7 +18,7 @@ public static class SwiftPostProcess
 
             var targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTestTargetName());
 
-            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "4.1.2");
+            var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "4.2.0");
             var mainTargetGuid = proj.GetUnityMainTargetGuid();
             var frameworkGuid = proj.GetUnityFrameworkTargetGuid();
             proj.AddRemotePackageFrameworkToProject(mainTargetGuid, "AppCoinsSDK", appCoinsGuid, false);

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -19,9 +19,9 @@ public static class SwiftPostProcess
             var targetGuid = proj.TargetGuidByName(PBXProject.GetUnityTestTargetName());
 
             var appCoinsGuid = proj.AddRemotePackageReferenceAtVersionUpToNextMajor("https://github.com/Catappult/appcoins-sdk-ios.git", "4.2.0");
+
             var mainTargetGuid = proj.GetUnityMainTargetGuid();
             var frameworkGuid = proj.GetUnityFrameworkTargetGuid();
-            proj.AddRemotePackageFrameworkToProject(mainTargetGuid, "AppCoinsSDK", appCoinsGuid, false);
             proj.AddRemotePackageFrameworkToProject(frameworkGuid, "AppCoinsSDK", appCoinsGuid, false);
 
             proj.SetBuildProperty(targetGuid, "ENABLE_BITCODE", "NO");


### PR DESCRIPTION
**What does this PR do?**

Removes the `AddRemotePackageFrameworkToProject` call that linked the AppCoinsSDK Swift Package to the main target (`Unity-iPhone`). The SDK is now linked only to the `UnityFramework` target, preventing every class from AppCoinsSDK, CryptoSwift, and web3swift from being compiled into both binaries and eliminating dozens of "Class X is implemented in both" runtime warnings.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs

**How should this be manually tested?**

1. Integrate the AppCoins SDK Unity Plugin into a Unity project
2. Build and run on iOS
3. Verify no "Class X is implemented in both .app and UnityFramework.framework" warnings appear in the console

QA Ticket: [APP-4060](https://aptoide.atlassian.net/browse/APP-4060)

**What are the relevant tickets?**

[APP-4060](https://aptoide.atlassian.net/browse/APP-4060)

**Questions:**

No new dependencies added.

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass