### PR TITLE
Bugfix/APP-4059 Wrap SwiftPostProcess with UNITY_EDITOR macro

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿#if UNITY_EDITOR
+using System.Collections.Generic;
 using UnityEditor;
 using UnityEditor.Callbacks;
 using UnityEditor.iOS.Xcode;
@@ -100,3 +101,4 @@ public static class SwiftPostProcess
         plistInfo.WriteToFile(plistInfoPath);
     }
 }
+#endif


### PR DESCRIPTION
**What does this PR do?**

Wraps the entire `SwiftPostProcess.cs` file with `#if UNITY_EDITOR` / `#endif` preprocessor directives. This file uses editor-only APIs (`UnityEditor`, `UnityEditor.Callbacks`, `UnityEditor.iOS.Xcode`) but was not guarded, which could cause compilation errors on iOS builds when Unity does not auto-exclude the file from the build despite being in an `Editor/` folder under `Plugins/iOS/`.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/Editor/SwiftPostProcess.cs

**How should this be manually tested?**

1. Import the AppCoins SDK Unity Plugin into a Unity project
2. Build the project for iOS
3. Verify `SwiftPostProcess.cs` does not cause compilation errors

QA Ticket: [APP-4059](https://aptoide.atlassian.net/browse/APP-4059)

**What are the relevant tickets?**

[APP-4059](https://aptoide.atlassian.net/browse/APP-4059)

**Questions:**

No new dependencies required.

**Code Review Checklist**

- [x] Documentation on public interfaces
- [x] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass