### PR TITLE
Feature/APP-4058 Add AppCoins namespace to Unity plugin classes

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsPurchaseManager.cs
@@ -2,6 +2,7 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using System;
+using AppCoins;
 
 // This class must match the name "AppCoinsPurchaseManager"
 public class AppCoinsPurchaseManager : MonoBehaviour

--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -4,6 +4,9 @@ using System.Threading.Tasks;
 using System;
 using System.Collections.Generic;
 
+namespace AppCoins
+{
+
 [Serializable]
 public class AppCoinsSDKError {
     public string Type;
@@ -634,9 +637,11 @@ public class AppCoinsSDK
     {
         if (_isObservingPurchases)
             return; // Prevent multiple registrations
-        
+
         _isObservingPurchases = true;
         _startPurchaseUpdates();
     }
     #endregion
 }
+
+} // namespace AppCoins

--- a/README.md
+++ b/README.md
@@ -24,15 +24,27 @@ The billing flow in your application with the Plugin is as follows:
 1. **Add AppCoins Unity Plugin**  
    In Unity, add the plugin from the latest release available on the repository <https://github.com/Catappult/appcoins-sdk-ios-unity-plugin> to your Assets folder.
 
+### Namespace
+
+All public classes in the plugin are defined under the `AppCoins` namespace. Add the following `using` directive at the top of any C# file that references plugin types:
+
+```csharp
+using AppCoins;
+```
+
+Alternatively, you can use fully qualified names (e.g., `AppCoins.Product`, `AppCoins.Purchase`).
+
 ### Implementation
 
 Now that you have the Plugin set-up you can start making use of its functionalities.
 
-1. **Check AppCoins Billing Availability**  
-   
+1. **Check AppCoins Billing Availability**
+
    The AppCoins Billing will only be available on devices with an iOS version equal to or higher than 17.4 and only if the application was not installed through the Apple App St. Therefore, before attempting any purchase, you should check if the SDK is available by calling `AppCoinsSDK.Instance.IsAvailable()`.
 
    ```csharp
+   using AppCoins;
+
    var isAvailable = await AppCoinsSDK.Instance.IsAvailable();
 
    if (isAvailable) 
@@ -49,6 +61,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
       Returns all application Catappult In-App Products:
 
       ```csharp
+      using AppCoins;
+
       var productsResult = await AppCoinsSDK.Instance.GetProducts();
 
       if (productsResult.IsSuccess)
@@ -67,6 +81,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
       Returns a specific list of Catappult In-App Products:
 
       ```csharp
+      using AppCoins;
+
       var productsResult = await AppCoinsSDK.Instance.GetProducts(new string[] { "coins_100", "gas" });
 
       if (productsResult.IsSuccess)
@@ -104,6 +120,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    <br/>
 
    ```csharp
+   using AppCoins;
+
    var purchaseResult = await AppCoinsSDK.Instance.Purchase("gas", "User123");
 
    switch (purchaseResult.State)
@@ -169,6 +187,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    Add this code to your application's startup logic (e.g., in your main scene's `Start()` or `Awake()` method):
 
    ```csharp
+   using AppCoins;
+
    private async void Start()
    {
        // Check if AppCoins Billing is available
@@ -241,6 +261,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
    <br/>
 
    ```csharp
+   using AppCoins;
+
    private void Awake()
    {
        // Singleton enforcement
@@ -312,6 +334,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
       This method returns all purchases that the user has performed in your application.
 
       ```csharp
+      using AppCoins;
+
       var purchasesResult = await AppCoinsSDK.Instance.GetAllPurchases();
 
       if (purchasesResult.IsSuccess)
@@ -330,6 +354,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
       This method returns the latest user purchase for a specific In-App Product. Returns `null` if no purchase is found.
 
       ```csharp
+      using AppCoins;
+
       var latestPurchaseResult = await AppCoinsSDK.Instance.GetLatestPurchase("gas");
 
       if (latestPurchaseResult.IsSuccess)
@@ -355,6 +381,8 @@ Now that you have the Plugin set-up you can start making use of its functionalit
       This method returns all of the user's unfinished purchases in the application. An unfinished purchase is any purchase that has neither been acknowledged (verified by the SDK) nor consumed. You can use this method for consuming any unfinished purchases.
 
       ```csharp
+      using AppCoins;
+
       var unfinishedPurchasesResult = await AppCoinsSDK.Instance.GetUnfinishedPurchases();
 
       if (unfinishedPurchasesResult.IsSuccess)


### PR DESCRIPTION
**What does this PR do?**

Wraps all public C# classes (`AppCoinsSDKError`, `AppCoinsSDKResult<T>`, `AppCoinsSDKPurchaseResult`, `Product`, `Purchase`, `PurchaseIntent`, `AppCoinsSDK`) in an `AppCoins` namespace to prevent naming conflicts with other SDKs that use the same class names (e.g., `UnityEngine.Purchasing.Product`, `Facebook.Unity.Product`).

Updates the README with a new "Namespace" section and adds `using AppCoins;` directives to all code examples.

**Note:** This is a breaking change. Developers upgrading will need to add `using AppCoins;` or use fully qualified names (e.g., `AppCoins.Product`).

**Database changed?**

No

**Where should the reviewer start?**

- [ ] AppCoinsSDK.cs
- [ ] AppCoinsPurchaseManager.cs
- [ ] README.md

**How should this be manually tested?**

1. Build the Unity project and verify it compiles without errors
2. Run the plugin on an iOS device and verify purchases work correctly
3. QA Ticket: [APP-4058](https://aptoide.atlassian.net/browse/APP-4058)

**What are the relevant tickets?**

[APP-4058](https://aptoide.atlassian.net/browse/APP-4058)

**Questions:**

No new dependencies required.

**Code Review Checklist**

- [ ] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [ ] Remove comments & unused code & forgotten testing Logs
- [ ] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass