### PR TITLE
Bugfix/APP-4068 Fix purchase state user_cancelled mismatch

### DIFF
--- a/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
+++ b/Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs
@@ -188,7 +188,7 @@ public class AppCoinsSDK
 
     public const string PURCHASE_STATE_SUCCESS = "success";
     public const string PURCHASE_STATE_PENDING = "pending";
-    public const string PURCHASE_STATE_USER_CANCELLED = "userCancelled";
+    public const string PURCHASE_STATE_USER_CANCELLED = "user_cancelled";
     public const string PURCHASE_STATE_FAILED = "failed";
 
     public const string PURCHASE_VERIFICATION_STATE_VERIFIED = "verified";


### PR DESCRIPTION
**What does this PR do?**

Fixes the `PURCHASE_STATE_USER_CANCELLED` constant in `AppCoinsSDK.cs` from `"userCancelled"` (camelCase) to `"user_cancelled"` (snake_case) to match the value sent by the native iOS Swift side. Without this fix, any C# code comparing `purchaseResult.State` against `AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED` would silently fail to detect user cancellations.

**Database changed?**

No

**Where should the reviewer start?**

- [ ] Assets/Plugins/iOS/AppCoinsSDKPlugin/AppCoinsSDK.cs

**How should this be manually tested?**

1. Initiate a purchase flow via the Unity plugin on iOS
2. Cancel the purchase
3. Verify that `purchaseResult.State == AppCoinsSDK.PURCHASE_STATE_USER_CANCELLED` returns `true`

QA Ticket: [APP-4068](https://aptoide.atlassian.net/browse/APP-4068)

**What are the relevant tickets?**

[APP-4068](https://aptoide.atlassian.net/browse/APP-4068)

**Questions:**

No new dependencies required.

**Code Review Checklist**

- [x] Documentation on public interfaces
- [ ] Database changed? If yes - Migration?
- [x] Remove comments & unused code & forgotten testing Logs
- [x] Codestyle
- [ ] New Kotlin code has unit tests
- [ ] New flows in presenters unit tests
- [ ] Mappers/Validators with any kind of logic unit tests
- [ ] Functional tests pass